### PR TITLE
Fix support for Apple Silicon

### DIFF
--- a/app/rust/Cargo.toml
+++ b/app/rust/Cargo.toml
@@ -36,7 +36,7 @@ version = "0.3.1"
 default-features = false
 features = ["check"]
 
-[target.'cfg(target_arch = "x86_64")'.dependencies]
+[target.'cfg(any(unix, windows))'.dependencies]
 getrandom = { version = "0.1.14", default-features = false }
 
 [target.thumbv6m-none-eabi.dev-dependencies]

--- a/app/rust/src/bolos.rs
+++ b/app/rust/src/bolos.rs
@@ -15,7 +15,7 @@ use blake2s_simd::{blake2s, Hash as Blake2sHash, Params as Blake2sParams};
 use core::convert::TryInto;
 use cstr_core::CStr;
 #[cfg(test)]
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(unix, windows))]
 use getrandom::getrandom;
 use jubjub::AffinePoint;
 use rand::{CryptoRng, RngCore};
@@ -369,21 +369,21 @@ impl RngCore for Trng {
         u64::from_le_bytes(out)
     }
 
-    #[cfg(not(target_arch = "x86_64"))]
+    #[cfg(not(any(unix, windows)))]
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         unsafe {
             bolos_cx_rng(dest.as_mut_ptr(), dest.len() as u32);
         }
     }
 
-    #[cfg(target_arch = "x86_64")]
     #[cfg(test)]
+    #[cfg(any(unix, windows))]
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         getrandom(dest).unwrap()
     }
 
-    #[cfg(target_arch = "x86_64")]
     #[cfg(not(test))]
+    #[cfg(any(unix, windows))]
     fn fill_bytes(&mut self, _dest: &mut [u8]) {}
 
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {


### PR DESCRIPTION
This PR allows the project to be unit tested on Apple Silicon (M1) machines.

This is done by refactoring the already present conditional compilation that previously depended on the target architecture to now depend on the [target family](https://doc.rust-lang.org/reference/conditional-compilation.html).