### PR TITLE
Upgrade to Neon 0.10

### DIFF
--- a/zcashtools/Cargo.lock
+++ b/zcashtools/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aes"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,6 +74,21 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e121dee8023ce33ab248d9ce1493df03c3b38a659b240096fcbd7048ff9c31f"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "bellman"
@@ -417,6 +447,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
+
+[[package]]
 name = "group"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -505,6 +541,16 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
 dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
+dependencies = [
+ "adler",
  "autocfg",
 ]
 
@@ -645,6 +691,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -779,6 +834,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -862,6 +923,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eba135d2c579aa65364522eb78590cdf703176ef71ad4c32b00f58f7afb2df5"
 dependencies = [
+ "backtrace",
  "doc-comment",
  "snafu-derive",
 ]
@@ -1044,6 +1106,7 @@ dependencies = [
  "neon-serde",
  "serde",
  "serde_derive",
+ "snafu",
  "zcash-hsmbuilder",
  "zcash_primitives",
 ]

--- a/zcashtools/Cargo.lock
+++ b/zcashtools/Cargo.lock
@@ -3,21 +3,6 @@
 version = 3
 
 [[package]]
-name = "addr2line"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
 name = "aes"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,21 +59,6 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
-name = "backtrace"
-version = "0.3.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e121dee8023ce33ab248d9ce1493df03c3b38a659b240096fcbd7048ff9c31f"
-dependencies = [
- "addr2line",
- "cc",
- "cfg-if 1.0.0",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
-]
 
 [[package]]
 name = "bellman"
@@ -324,12 +294,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cslice"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697c714f50560202b1f4e2e09cd50a421881c83e9025db75d15f276616f04f40"
-
-[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -359,6 +323,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
 name = "equihash"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,16 +336,6 @@ checksum = "4127688f6177e3f57521881cb1cfd90d1228214f9dc43b8efe6f6c6948cd8280"
 dependencies = [
  "blake2b_simd",
  "byteorder",
-]
-
-[[package]]
-name = "error-chain"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
-dependencies = [
- "backtrace",
- "version_check",
 ]
 
 [[package]]
@@ -457,12 +417,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
-
-[[package]]
 name = "group"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,6 +426,15 @@ dependencies = [
  "ff",
  "rand_core",
  "subtle",
+]
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -546,22 +509,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "miniz_oxide"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
-dependencies = [
- "adler",
- "autocfg",
-]
-
-[[package]]
 name = "neon"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e85820b585bf3360bf158ac87a75764c48e361c91bbeb69873e6613cc78c023"
+checksum = "544694d02bbff81f78dba5ef7d29341cc6d256edcae4fbb2d684491d5755c748"
 dependencies = [
- "cslice",
  "neon-build",
  "neon-runtime",
  "semver",
@@ -570,18 +522,18 @@ dependencies = [
 
 [[package]]
 name = "neon-build"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad9febc63f515156d4311a0c43899d3ace46352ecdd591c21b98ca3974f2a0d0"
+checksum = "cd4ec682b1a7837c84d9866c342ac6ffe2ce9712e844e4015f31d01bdeb73608"
 dependencies = [
  "neon-sys",
 ]
 
 [[package]]
 name = "neon-runtime"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02662cd2e62b131937bdef85d0918b05bc3c204daf4c64af62845403eccb60f3"
+checksum = "5c4b1a7f8f569b4e43feff04931924cebe40a630fa258d2a28147525d247defe"
 dependencies = [
  "cfg-if 1.0.0",
  "neon-sys",
@@ -590,22 +542,19 @@ dependencies = [
 
 [[package]]
 name = "neon-serde"
-version = "0.4.0"
-source = "git+https://github.com/Zondax/neon-serde#4738dc8e72c53926926321fe20fcc2fd02b5bd7c"
+version = "0.10.0"
 dependencies = [
- "error-chain",
  "neon",
- "neon-runtime",
- "neon-sys",
  "num",
  "serde",
+ "snafu",
 ]
 
 [[package]]
 name = "neon-sys"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc2fd32e08c4681b0004b3dce16a9f647a8023af7b8dde3bb3ac423034803830"
+checksum = "c376c75ccf632a20d2f18fd2bde0b10f36a9cc5c8c7c4921f629147ebf59aeb6"
 dependencies = [
  "cc",
  "regex",
@@ -693,15 +642,6 @@ checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
  "libc",
-]
-
-[[package]]
-name = "object"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -839,12 +779,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
-
-[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -923,6 +857,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
+name = "snafu"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eba135d2c579aa65364522eb78590cdf703176ef71ad4c32b00f58f7afb2df5"
+dependencies = [
+ "doc-comment",
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a7fe9b0669ef117c5cabc5549638528f36771f058ff977d7689deb517833a75"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -944,6 +900,12 @@ name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
 name = "unicode-xid"

--- a/zcashtools/neon/native/Cargo.toml
+++ b/zcashtools/neon/native/Cargo.toml
@@ -12,12 +12,12 @@ name = "zcashtool"
 crate-type = ["cdylib"]
 
 [build-dependencies]
-neon-build = "0.9.1"
+neon-build = "0.10"
 
 [dependencies]
-neon = "0.9.1"
+neon = "0.10"
 zcash-hsmbuilder = "0.2"
-neon-serde = { git = "https://github.com/Zondax/neon-serde" }
+neon-serde = { git = "https://github.com/becominginsane/neon-serde", branch = "refactor/neon@0.10" }
 serde_derive = "1.0.136"
 serde = "1"
 zcash_primitives = "0.5.0"

--- a/zcashtools/neon/native/Cargo.toml
+++ b/zcashtools/neon/native/Cargo.toml
@@ -21,3 +21,6 @@ neon-serde = { git = "https://github.com/becominginsane/neon-serde", branch = "r
 serde_derive = "1.0.136"
 serde = "1"
 zcash_primitives = "0.5.0"
+
+#activate snafu backtraces
+snafu = { version = "0.7", features = ["backtraces"] }

--- a/zcashtools/neon/native/Cargo.toml
+++ b/zcashtools/neon/native/Cargo.toml
@@ -17,7 +17,7 @@ neon-build = "0.10"
 [dependencies]
 neon = "0.10"
 zcash-hsmbuilder = "0.2"
-neon-serde = { git = "https://github.com/becominginsane/neon-serde", branch = "refactor/neon@0.10" }
+neon-serde = { git = "https://github.com/Zondax/neon-serde" }
 serde_derive = "1.0.136"
 serde = "1"
 zcash_primitives = "0.5.0"

--- a/zcashtools/neon/native/src/lib.rs
+++ b/zcashtools/neon/native/src/lib.rs
@@ -1,10 +1,8 @@
-extern crate neon;
-extern crate neon_serde;
+use neon::prelude::*;
 
 use std::path::Path;
 
-use neon::prelude::*;
-
+use neon_serde::ResultExt;
 use zcash_hsmbuilder::errors::Error;
 use zcash_hsmbuilder::*;
 
@@ -16,11 +14,11 @@ use zcash_hsmbuilder::*;
 fn get_inittx_data(mut cx: FunctionContext) -> JsResult<JsValue> {
     // First get call arguments
     let arg0 = cx.argument::<JsValue>(0)?;
-    let arg0_value: InitData = neon_serde::from_value(&mut cx, arg0)?;
+    let arg0_value: InitData = neon_serde::from_value(&mut cx, arg0).throw(&mut cx)?;
     let output = arg0_value.to_hsm_bytes();
     let js_value;
     if output.is_ok() {
-        js_value = neon_serde::to_value(&mut cx, &output.unwrap())?;
+        js_value = neon_serde::to_value(&mut cx, &output.unwrap()).throw(&mut cx)?;
         Ok(js_value)
     } else {
         cx.throw_error(output.err().unwrap().to_string())
@@ -77,7 +75,7 @@ declare_types! {
 
         method add_transparent_input(mut cx) {
             let arg0 = cx.argument::<JsValue>(0)?;
-            let arg0_value :TransparentInputBuilderInfo = neon_serde::from_value(&mut cx, arg0)?;
+            let arg0_value :TransparentInputBuilderInfo = neon_serde::from_value(&mut cx, arg0).throw(&mut cx)?;
             let value;
             {
             let mut this = cx.this();
@@ -96,7 +94,7 @@ declare_types! {
 
         method add_transparent_output(mut cx) {
             let arg0 = cx.argument::<JsValue>(0)?;
-            let arg0_value :TransparentOutputBuilderInfo = neon_serde::from_value(&mut cx, arg0)?;
+            let arg0_value :TransparentOutputBuilderInfo = neon_serde::from_value(&mut cx, arg0).throw(&mut cx)?;
             let value;
             {
             let mut this = cx.this();
@@ -115,7 +113,7 @@ declare_types! {
 
         method add_sapling_spend(mut cx) {
             let arg0 = cx.argument::<JsValue>(0)?;
-            let arg0_value :SpendBuilderInfo = neon_serde::from_value(&mut cx, arg0)?;
+            let arg0_value :SpendBuilderInfo = neon_serde::from_value(&mut cx, arg0).throw(&mut cx)?;
             let value;
             {
             let mut this = cx.this();
@@ -134,7 +132,7 @@ declare_types! {
 
         method add_sapling_output(mut cx) {
             let arg0 = cx.argument::<JsValue>(0)?;
-            let arg0_value :OutputBuilderInfo = neon_serde::from_value(&mut cx, arg0)?;
+            let arg0_value :OutputBuilderInfo = neon_serde::from_value(&mut cx, arg0).throw(&mut cx)?;
             let value;
             {
             let mut this = cx.this();
@@ -164,7 +162,7 @@ declare_types! {
             value = thishandler.build(&spendpath, &outputpath);
             }
             if value.is_ok(){
-                let js_value = neon_serde::to_value(&mut cx, &value.unwrap())?;
+                let js_value = neon_serde::to_value(&mut cx, &value.unwrap()).throw(&mut cx)?;
                 Ok(js_value)
             }else{
                 cx.throw_error(value.err().unwrap().to_string())
@@ -173,7 +171,7 @@ declare_types! {
 
         method add_signatures(mut cx) {
             let arg0 = cx.argument::<JsValue>(0)?;
-            let arg0_value :TransactionSignatures = neon_serde::from_value(&mut cx, arg0)?;
+            let arg0_value :TransactionSignatures = neon_serde::from_value(&mut cx, arg0).throw(&mut cx)?;
             let value;
             {
             let mut this = cx.this();
@@ -200,7 +198,7 @@ declare_types! {
             value = thishandler.finalize();
             }
             if value.is_ok(){
-                let js_value = neon_serde::to_value(&mut cx, &value.unwrap())?;
+                let js_value = neon_serde::to_value(&mut cx, &value.unwrap()).throw(&mut cx)?;
                 Ok(js_value)
             }else{
                 cx.throw_error(value.err().unwrap().to_string())


### PR DESCRIPTION
This PR upgrades zcashtools to Neon 0.10.

The crate `neon-serde` can depend on the original URL once [the update PR](https://github.com/Zondax/neon-serde/pull/1) is merged