### PR TITLE
[ZIP-0317] Adopt proportional transfer fee convention

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -63,7 +63,7 @@ endif
 
 include $(CURDIR)/../deps/ledger-zxlib/makefiles/Makefile.platform
 
-DEFINES		  += HAVE_HASH HAVE_BLAKE2 HAVE_SHA256 HAVE_SHA512
+DEFINES		  += HAVE_HASH HAVE_BLAKE2 HAVE_SHA256 HAVE_SHA512 HAVE_ZIP0317
 APP_SOURCE_PATH += $(CURDIR)/rust/include
 APP_SOURCE_PATH += $(MY_DIR)/../deps/tiny-aes/src
 

--- a/app/src/crypto.c
+++ b/app/src/crypto.c
@@ -29,6 +29,7 @@
 #include "rslib.h"
 #include "sighash.h"
 #include "txid.h"
+#include "zip-0317.h"
 #include "zxformat.h"
 #include "zxmacros.h"
 
@@ -357,10 +358,16 @@ zxerr_t crypto_extracttx_sapling(uint8_t *buffer, uint16_t bufferLen,
     start += OUTPUT_INPUT_LEN;
   }
 
-  uint64_t value_flash = get_totalvalue();
-  if (value_flash != 1000) {
+  uint64_t tx_value__flash = get_totalvalue();
+#ifdef HAVE_ZIP0317
+  if (tx_value__flash != zip_0317(t_in_len, t_out_len, spend_len, output_len)) {
     return (zxerr_t)EXTRACT_SAPLING_ED;
   }
+#else
+  if (tx_value__flash != 1000) {
+    return (zxerr_t)EXTRACT_SAPLING_ED;
+  }
+#endif
 
   if (spend_len > 0) {
     set_state(STATE_PROCESSED_INPUTS); // need both spend info and output info

--- a/app/src/zip-0317.c
+++ b/app/src/zip-0317.c
@@ -1,0 +1,39 @@
+#include "zip-0317.h"
+
+#define DIV_CEIL(x, y) ((x + (y - 1)) / y)
+
+#define MARGINAL_FEE 5000
+#define GRACE_ACTIONS 2
+#define P2PKH_STANDARD_INPUT_SIZE 150
+#define P2PKH_STANDARD_OUTPUT_SIZE 34
+
+uint64_t zip_0317_fee_raw(uint64_t tx_in_total_size, uint64_t tx_out_total_size,
+                          uint64_t n_join_split, uint64_t n_spends_sapling,
+                          uint64_t n_outputs_sapling,
+                          uint64_t n_actions_orchard) {
+
+  uint64_t tin_actions = DIV_CEIL(tx_in_total_size, P2PKH_STANDARD_INPUT_SIZE);
+  uint64_t tout_actions =
+      DIV_CEIL(tx_out_total_size, P2PKH_STANDARD_OUTPUT_SIZE);
+
+  uint64_t transparent_actions =
+      (tin_actions > tout_actions) ? tin_actions : tout_actions;
+  uint64_t sapling_actions = (n_spends_sapling > n_outputs_sapling)
+                                 ? n_spends_sapling
+                                 : n_outputs_sapling;
+  uint64_t joinsplit_actions = 2 * n_join_split;
+  uint64_t orchard_actions = n_actions_orchard;
+
+  uint64_t logical_actions = transparent_actions + sapling_actions +
+                             joinsplit_actions + orchard_actions;
+
+  return MARGINAL_FEE *
+         ((GRACE_ACTIONS > logical_actions) ? GRACE_ACTIONS : logical_actions);
+}
+
+uint64_t zip_0317(uint64_t n_tin, uint64_t n_tout, uint64_t n_sapling_spends,
+                  uint64_t n_sapling_outs) {
+  return zip_0317_fee_raw(n_tin * P2PKH_STANDARD_INPUT_SIZE,
+                          n_tout * P2PKH_STANDARD_OUTPUT_SIZE, 0,
+                          n_sapling_spends, n_sapling_outs, 0);
+}

--- a/app/src/zip-0317.h
+++ b/app/src/zip-0317.h
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ *   (c) 2018 - 2023 Zondax AG
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ********************************************************************************/
+
+#pragma once
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+uint64_t zip_0317(uint64_t n_tin, uint64_t n_tout, uint64_t n_sapling_spends,
+                  uint64_t n_sapling_outs);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
This PR implements a different fee calculation convention according to [https://github.com/zcash/zips/blob/main/zip-0317.rst](ZIP-0317), adjusting the check done in the app code.

A define is used to easily toggle the feature on or off during compilation.

NB: branched on top of #83

<!-- ClickUpRef: 86930djm7 -->
:link: [zboto Link](https://app.clickup.com/t/86930djm7)