### PR TITLE
Fix/nullifier

### DIFF
--- a/app/rust/src/bolos/zemu.rs
+++ b/app/rust/src/bolos/zemu.rs
@@ -5,9 +5,9 @@ extern "C" {
 }
 
 #[cfg(not(test))]
-pub fn c_zemu_log_stack(s: &[u8]) {
+pub fn c_zemu_log_stack(s: &str) {
     unsafe { zemu_log_stack(s.as_ptr()) }
 }
 
 #[cfg(test)]
-pub fn c_zemu_log_stack(_s: &[u8]) {}
+pub fn c_zemu_log_stack(_s: &str) {}

--- a/app/rust/src/commitments_extern.rs
+++ b/app/rust/src/commitments_extern.rs
@@ -15,7 +15,7 @@ pub extern "C" fn compute_nullifier(
     nsk_ptr: *const NskBytes,
     out_ptr: *mut NfBytes,
 ) {
-    c_zemu_log_stack(b"compute_nullifier\x00".as_ref());
+    c_zemu_log_stack("compute_nullifier\x00");
     let ncm = unsafe { *ncm_ptr };
     let nsk = unsafe { &*nsk_ptr };
     let out = unsafe { &mut *out_ptr };
@@ -43,20 +43,36 @@ pub extern "C" fn compute_note_commitment(
     pkd_ptr: *const [u8; 32],
     out_ptr: *mut [u8; 32],
 ) {
+    c_zemu_log_stack("----[compute_note_commitment]\x00");
+
     let rcm = unsafe { &*rcm_ptr };
     let diversifier = unsafe { &*diversifier_ptr };
     let pkd = unsafe { &*pkd_ptr };
     let out = unsafe { &mut *out_ptr };
 
-    let mut gd = [0u8; 32];
-    commitments::group_hash_from_diversifier(diversifier, &mut gd);
-    commitments::prepare_and_hash_input_commitment(value, &gd, pkd, out);
+    // commented code was previous implementation
+    // and was given an invalid commitment. code is left here
+    // for further investigation
 
-    let mut e = cryptoops::bytes_to_extended(*out);
-    let s = multiply_with_pedersen_base(rcm);
-    add_to_point(&mut e, &s);
+    // let mut gd = [0u8; 32];
 
-    out.copy_from_slice(&extended_to_u_bytes(&e));
+    let gd = crate::zip32::compute_g_d(diversifier);
+
+    // commitments::group_hash_from_diversifier(diversifier, &mut gd);
+    // commitments::prepare_and_hash_input_commitment(value, &gd, pkd, out);
+    // let mut e = cryptoops::bytes_to_extended(*out);
+    // let s = multiply_with_pedersen_base(rcm);
+    // add_to_point(&mut e, &s);
+
+    // TODO: We need to test note_commitment function at runtime
+    // to discard any stack/pic issues
+    let commitment_point = crate::commitments::note_commitment(value, &gd, pkd, rcm);
+
+    // Convert the commitment point to bytes
+    let cm_bytes = group::GroupEncoding::to_bytes(&commitment_point);
+
+    // out.copy_from_slice(&extended_to_u_bytes(&e));
+    out.copy_from_slice(cm_bytes.as_ref());
 }
 
 //////////////////////////////

--- a/app/rust/src/redjubjub_extern.rs
+++ b/app/rust/src/redjubjub_extern.rs
@@ -14,7 +14,7 @@ pub extern "C" fn sign_redjubjub(
     msg_ptr: *const [u8; 64],
     out_ptr: *mut [u8; 64],
 ) {
-    c_zemu_log_stack(b"sign_redjubjub\x00".as_ref());
+    c_zemu_log_stack("sign_redjubjub\x00");
     let key = unsafe { *key_ptr };
     let msg = unsafe { *msg_ptr };
     let output = unsafe { &mut *out_ptr };

--- a/app/rust/src/zip32.rs
+++ b/app/rust/src/zip32.rs
@@ -167,6 +167,13 @@ pub fn diversifier_find_valid(dk: &DkBytes, start: &Diversifier) -> Diversifier 
     div_out
 }
 
+pub fn compute_g_d(d: &[u8; 11]) -> [u8; 32] {
+    let h = blake2b::blake2s_diversification(d);
+    let v = AffinePoint::from_bytes(h).unwrap();
+    let g_d = v.mul_by_cofactor();
+    group::GroupEncoding::to_bytes(&g_d)
+}
+
 #[inline(never)]
 pub fn diversifier_get_list(
     dk: &DkBytes,


### PR DESCRIPTION
- make log function easier to use
- Fix note commitment computation 
- add a nullifier test that use the fix to check we get the same nullifier as zcash for the same input data
- TODO: Add a test to check if note commitment is correct using a reference implementation like zcash


<!-- ClickUpRef: 86954uddu -->
:link: [zboto Link](https://app.clickup.com/t/86954uddu)