### PR TITLE
Update GitHub Actions setup-node from v3 to v4

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,7 +20,7 @@ jobs:
         with:
           submodules: true
       - name: Install node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           registry-url: "https://registry.npmjs.org"
           scope: "@zondax"


### PR DESCRIPTION

Changes made:
- Old: actions/setup-node@v3
+ New: actions/setup-node@v4

Reason for changes:
Updating to the latest version (v4.4.0) of the setup-node action to get:
- Latest security updates
- Performance improvements
- Bug fixes
- Support for newer Node.js versions

Source: https://github.com/actions/setup-node
Latest release: v4.4.0 (April 2024)

<!-- ClickUpRef: 8699fwx5e -->
:link: [zboto Link](https://app.clickup.com/t/8699fwx5e)